### PR TITLE
DMメッセージ応答の修正とエージェント処理機能の強化

### DIFF
--- a/src/agents/command-parser-agent.js
+++ b/src/agents/command-parser-agent.js
@@ -1,5 +1,34 @@
 class CommandParserAgent {
-  static async run({ message }, context) {
+  static async process(message) {
+    console.log(`CommandParserAgent processing message: ${message}`);
+    
+    if (!message || typeof message !== 'string') {
+      console.log('Invalid message format. Expected string but got:', typeof message);
+      return { command: 'chatDefault', args: message };
+    }
+
+    // コマンド前置詞の検出
+    const prefix = process.env.PREFIX || '!';
+    
+    // コマンドの処理
+    if (message.startsWith(prefix)) {
+      const args = message.slice(prefix.length).trim().split(/ +/);
+      const command = args.shift().toLowerCase();
+      
+      console.log(`Detected command: ${command}, with args:`, args);
+      
+      if (command === 'help') {
+        return { command: 'help' };
+      } else if (command === 'search' || command === 'web') {
+        return { command: 'webSearch', args: args.join(' ') };
+      } else if (command === 'clear') {
+        return { command: 'clearChat' };
+      } else if (command === 'image') {
+        return { command: 'generateImage', args: args.join(' ') };
+      }
+    }
+    
+    // Web検索トリガーの検出
     const searchTriggers = [
       '検索して', 
       '調べて', 
@@ -16,15 +45,18 @@ class CommandParserAgent {
     );
 
     let query = message;
-    searchTriggers.forEach(trigger => {
-      query = query.replace(new RegExp(trigger, 'gi'), '').trim();
-    });
+    if (isWebSearch) {
+      searchTriggers.forEach(trigger => {
+        query = query.replace(new RegExp(trigger, 'gi'), '').trim();
+      });
+      
+      console.log(`Detected web search with query: ${query}`);
+      return { command: 'webSearch', args: query };
+    }
 
-    return {
-      isWebSearch: isWebSearch,
-      query: query,
-      originalMessage: message
-    };
+    // 通常のチャットメッセージとして処理
+    console.log('Processing as chat message');
+    return { command: 'chatDefault', args: message };
   }
 }
 

--- a/src/agents/search-result-formatter-agent.js
+++ b/src/agents/search-result-formatter-agent.js
@@ -1,18 +1,39 @@
 class SearchResultFormatterAgent {
-  static async run({ results }, context) {
-    if (!results || results.length === 0) {
-      return {
-        formattedResults: '検索結果が見つかりませんでした。'
-      };
+  static async process(searchData) {
+    console.log('SearchResultFormatterAgent processing search results');
+    
+    if (!searchData) {
+      console.log('No search data provided');
+      return '検索データが提供されていません。';
+    }
+    
+    // エラーチェック
+    if (searchData.type === 'error' || searchData.error) {
+      console.log(`Search error: ${searchData.message || searchData.error}`);
+      return `検索中にエラーが発生しました: ${searchData.message || searchData.error || '不明なエラー'}`;
+    }
+    
+    const results = searchData.results || [];
+    if (results.length === 0) {
+      console.log('No search results found');
+      return '検索結果が見つかりませんでした。別のキーワードで試してみてください。';
     }
 
-    const formattedResults = results.map((result, index) => 
-      `${index + 1}. ${result.title}\n${result.link}\n${result.snippet}\n`
-    ).join('\n');
-
-    return {
-      formattedResults: formattedResults
-    };
+    console.log(`Formatting ${results.length} search results`);
+    
+    // 結果をフォーマット
+    const query = searchData.query || '';
+    let formattedOutput = `## "${query}" の検索結果\n\n`;
+    
+    results.forEach((result, index) => {
+      formattedOutput += `### ${index + 1}. ${result.title}\n`;
+      formattedOutput += `${result.link}\n\n`;
+      formattedOutput += `${result.snippet || '説明なし'}\n\n`;
+    });
+    
+    formattedOutput += `\n合計 ${results.length} 件の結果`;
+    
+    return formattedOutput;
   }
 }
 

--- a/src/agents/web-search-agent.js
+++ b/src/agents/web-search-agent.js
@@ -1,17 +1,27 @@
 import { brave_web_search } from '../utils/brave-search.js';
 
 class WebSearchAgent {
-  static async run({ query }, context) {
-    const { 
-      count = 5, 
-      safeSearch = true 
-    } = context.params || {};
+  static async process(query) {
+    console.log(`WebSearchAgent processing query: "${query}"`);
+    
+    if (!query || typeof query !== 'string' || query.trim() === '') {
+      console.log('Invalid or empty search query');
+      return { 
+        type: 'error',
+        message: '検索クエリが無効または空です。',
+        results: []
+      };
+    }
 
     try {
+      console.log(`Executing web search for: "${query}"`);
+      
       const searchResults = await brave_web_search(query, {
-        count, 
-        safe: safeSearch
+        count: 5, 
+        safe: true
       });
+
+      console.log(`Received ${searchResults.length} search results for query "${query}"`);
 
       return {
         type: 'web_search',
@@ -28,7 +38,8 @@ class WebSearchAgent {
       return {
         type: 'error',
         message: '検索中にエラーが発生しました',
-        details: error.toString()
+        details: error.toString(),
+        results: []
       };
     }
   }

--- a/src/flows/web-search-flow.js
+++ b/src/flows/web-search-flow.js
@@ -8,7 +8,7 @@ export default {
       next: "commandParser"
     },
 
-    // コマンドパーサーノード - ユーザー入力を解析します
+    // コマンドパーサーノード - ユーザ入力を解析します
     commandParser: {
       type: "agent",
       agent: "commandParserAgent",
@@ -22,7 +22,7 @@ export default {
           target: "helpCommand"
         },
         {
-          condition: "result.command === 'chat'",
+          condition: "result.command === 'chatDefault'",
           target: "chatDefault"
         },
         {
@@ -51,8 +51,7 @@ export default {
     // ヘルプコマンドノード - ヘルプテキストを生成します
     helpCommand: {
       type: "value",
-      value: `
-## 🤖 ボッチーボット ヘルプ
+      value: `## 🔖 ボッチーボット ヘルプ
 
 以下のコマンドが利用できます:
 
@@ -73,7 +72,7 @@ export default {
       next: "output"
     },
 
-    // 出力ノード - 最終的な応答を返します
+    // 出力ノード - 最終的な結果を返します
     output: {
       type: "output"
     }

--- a/src/utils/brave-search.js
+++ b/src/utils/brave-search.js
@@ -8,24 +8,48 @@ export async function brave_web_search(query, options = {}) {
     count = 5,
     offset = 0,
     safe = true,
-    country = 'US',
-    language = 'en'
+    country = 'JP',  // 日本の検索結果を優先
+    language = 'ja'  // 日本語の検索結果を優先
   } = options;
 
+  if (!query || typeof query !== 'string' || query.trim() === '') {
+    console.log('Invalid or empty search query');
+    return [];
+  }
+
+  console.log(`Brave Search API querying: "${query}"`);
+
   try {
-    const response = await fetch(`https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}`, {
+    const apiKey = process.env.BRAVE_API_KEY;
+    if (!apiKey) {
+      console.error('BRAVE_API_KEY is not set in environment variables');
+      throw new Error('API キーが設定されていません');
+    }
+
+    // Brave Search APIにリクエスト
+    const response = await fetch(`https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}&count=${count}&offset=${offset}&country=${country}&language=${language}`, {
       method: 'GET',
       headers: {
-        'X-Subscription-Token': process.env.BRAVE_API_KEY,
-        'Accept': 'application/json'
+        'X-Subscription-Token': apiKey,
+        'Accept': 'application/json',
+        'Accept-Language': 'ja'
       }
     });
 
     if (!response.ok) {
-      throw new Error(`Brave検索APIエラー: ${response.status} ${response.statusText}`);
+      const errorText = await response.text().catch(() => 'Unknown error');
+      console.error(`Brave API error: ${response.status} ${response.statusText}`, errorText);
+      throw new Error(`検索API エラー: ${response.status} ${response.statusText}`);
     }
 
     const data = await response.json();
+    
+    if (!data.web || !data.web.results) {
+      console.log('No search results found or invalid response format');
+      return [];
+    }
+
+    console.log(`Received ${data.web.results.length} raw search results, returning up to ${count}`);
 
     return data.web.results.map(result => ({
       title: result.title,


### PR DESCRIPTION
## 修正内容

Discord BotがDMに反応しない問題を修正するために、以下の改善を行いました：

### 1. CommandParserAgent の修正
- `process` メソッドの実装を追加
- エラーハンドリングを強化
- コマンドの検出と処理を改善
- デバッグログを強化

### 2. WebSearchAgent の修正
- `process` メソッドの実装を追加
- 入力検証の追加
- エラーハンドリングの改善
- ログ出力を追加

### 3. SearchResultFormatterAgent の修正
- `process` メソッドの実装を追加
- 出力フォーマットを改善
- エラー条件の処理を強化

### 4. Brave検索API関連の修正
- 日本語検索の優先度向上
- エラーハンドリングの強化
- ログ出力の追加

### 5. Web検索フローの改善
- 処理フローを明確化
- コードのコメントを追加
- `chatDefault` コマンド対応を改善

## テスト方法

1. ALLOW_ALL_SERVERS=true に設定 (環境変数で追加済み)
2. ENABLE_DM=true を追加 (環境変数で追加済み)
3. DMメッセージを送信して応答をテスト
4. ログで挙動を確認

## 技術的詳細

DMに応答するためには以下の問題点を修正する必要がありました：

1. 各エージェントの `run` メソッドではなく、実際に呼び出される `process` メソッドが実装されていない
2. コマンドパーサーが適切にDMメッセージを処理していない
3. エラーハンドリングが不十分でログが出力されていない
4. フローが適切に定義されていない

これらの問題を修正することで、DMメッセージへの応答が可能になります。